### PR TITLE
Clinc version 0.2.0

### DIFF
--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -120,4 +120,20 @@ allExamples = concat
              , "five and half min"
              , "5 and an half minute"
              ]
+-- clinc support
+  , examples (DurationData 1 Day)
+             [ "every day"
+             , "per day"
+             , "daily"
+             ]
+  , examples (DurationData 1 Week)
+             [ "every week"
+             , "per week"
+             , "weekly"
+             ]
+  , examples (DurationData 1 Year)
+             [ "every year"
+             , "per year"
+             , "yearly"
+             ]
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -240,6 +240,34 @@ ruleCompositeDuration = Rule
       _ -> Nothing
   }
 
+-- Clinc specify rule. Weekly test.
+ruleDurationDaily :: Rule
+ruleDurationDaily = Rule
+  { name = "daily"
+  , pattern =
+    [ regex "daily|(every day)|(per day)"
+    ]
+  , prod = \_ -> Just . Token Duration $ duration TG.Day 1
+  }
+
+ruleDurationWeekly :: Rule
+ruleDurationWeekly = Rule
+  { name = "weekly"
+  , pattern =
+    [ regex "weekly|(every week)|(per week)"
+    ]
+  , prod = \_ -> Just . Token Duration $ duration TG.Week 1
+  }
+
+ruleDurationYearly :: Rule
+ruleDurationYearly = Rule
+  { name = "yearly"
+  , pattern =
+    [ regex "yearly|(every year)|(per year)"
+    ]
+  , prod = \_ -> Just . Token Duration $ duration TG.Year 1
+  }
+
 rules :: [Rule]
 rules =
   [ ruleDurationQuarterOfAnHour
@@ -258,4 +286,8 @@ rules =
   , ruleNumeralQuotes
   , ruleCompositeDuration
   , ruleCompositeDurationCommasAnd
+  -- clinc 
+  , ruleDurationDaily
+  , ruleDurationWeekly
+  , ruleDurationYearly
   ]

--- a/Duckling/Ranking/Classifiers/EN_AU.hs
+++ b/Duckling/Ranking/Classifiers/EN_AU.hs
@@ -864,12 +864,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1588,10 +1587,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_BZ.hs
+++ b/Duckling/Ranking/Classifiers/EN_BZ.hs
@@ -864,12 +864,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1588,10 +1587,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_CA.hs
+++ b/Duckling/Ranking/Classifiers/EN_CA.hs
@@ -877,12 +877,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1624,10 +1623,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_GB.hs
+++ b/Duckling/Ranking/Classifiers/EN_GB.hs
@@ -871,12 +871,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1612,10 +1611,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_IE.hs
+++ b/Duckling/Ranking/Classifiers/EN_IE.hs
@@ -864,12 +864,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1588,10 +1587,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_IN.hs
+++ b/Duckling/Ranking/Classifiers/EN_IN.hs
@@ -864,12 +864,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1588,10 +1587,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_JM.hs
+++ b/Duckling/Ranking/Classifiers/EN_JM.hs
@@ -864,12 +864,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1588,10 +1587,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_NZ.hs
+++ b/Duckling/Ranking/Classifiers/EN_NZ.hs
@@ -864,12 +864,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1588,10 +1587,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_PH.hs
+++ b/Duckling/Ranking/Classifiers/EN_PH.hs
@@ -864,12 +864,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1588,10 +1587,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_TT.hs
+++ b/Duckling/Ranking/Classifiers/EN_TT.hs
@@ -864,12 +864,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1588,10 +1587,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_US.hs
+++ b/Duckling/Ranking/Classifiers/EN_US.hs
@@ -885,12 +885,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1642,10 +1641,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_XX.hs
+++ b/Duckling/Ranking/Classifiers/EN_XX.hs
@@ -867,12 +867,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.457246097092175, unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.4000876832522264, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.26510775041324197,
-                               unseen = -4.060443010546419,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 56}}),
+                     ClassData{prior = -0.28312625591592017, unseen = -4.04305126783455,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 55}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1602,10 +1601,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/EN_ZA.hs
+++ b/Duckling/Ranking/Classifiers/EN_ZA.hs
@@ -864,12 +864,11 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("hour (grain)",
         Classifier{okData =
-                     ClassData{prior = -1.4294665329850993,
-                               unseen = -2.9444389791664407,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 17},
+                     ClassData{prior = -1.3723081191451507, unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
                    koData =
-                     ClassData{prior = -0.27369583047704105, unseen = -4.02535169073515,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 54}}),
+                     ClassData{prior = -0.2923879634891936, unseen = -4.007333185232471,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 53}}),
        ("Parsi New Year",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.791759469228055,
@@ -1588,10 +1587,14 @@ classifiers
                                n = 1}}),
        ("number.number hours",
         Classifier{okData =
-                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
+                               likelihoods =
+                                 HashMap.fromList
+                                   [("hour (grain)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("from <time-of-day> - <time-of-day> (interval)",
         Classifier{okData =

--- a/Duckling/Time/EN/Rules.hs
+++ b/Duckling/Time/EN/Rules.hs
@@ -133,6 +133,7 @@ ruleInstants = mkRuleInstants
   , ("today"        , TG.Day   , 0  , "todays?|(at this time)"           )
   , ("tomorrow"     , TG.Day   , 1  , "(tmrw?|tomm?or?rows?)"            )
   , ("yesterday"    , TG.Day   , - 1, "yesterdays?"                      )
+  , ("present"      , TG.Day   , 0,   "present?"                         )
   ]
 
 ruleNow :: Rule
@@ -1143,10 +1144,10 @@ ruleIntervalFromMonthDDDD :: Rule
 ruleIntervalFromMonthDDDD = Rule
   { name = "from <month> dd-dd (interval)"
   , pattern =
-    [ regex "from"
+    [ regex "(from|between)"
     , Predicate isAMonth
     , Predicate isDOMValue
-    , regex "\\-|to|th?ru|through|(un)?til(l)?"
+    , regex "\\-|to( the)?|and( the)?|th?ru|through|(un)?til(l)?"
     , Predicate isDOMValue
     ]
   , prod = \tokens -> case tokens of
@@ -1166,9 +1167,9 @@ ruleIntervalFromDDDDMonth :: Rule
 ruleIntervalFromDDDDMonth = Rule
   { name = "from the <day-of-month> (ordinal or number) to the <day-of-month> (ordinal or number) <named-month> (interval)"
   , pattern =
-    [ regex "from( the)?"
+    [ regex "(from|between)( the)?"
     , Predicate isDOMValue
-    , regex "\\-|to( the)?|th?ru|through|(un)?til(l)?"
+    , regex "\\-|to( the)?|and( the)?|th?ru|through|(un)?til(l)?"
     , Predicate isDOMValue
     , Predicate isAMonth
     ]
@@ -2249,13 +2250,15 @@ ruleDurationHenceAgo = Rule
   { name = "<duration> hence|ago"
   , pattern =
     [ dimension Duration
-    , regex "(hence|ago)"
+    , regex "(hence|later|before|previous|ago)"
     ]
   , prod = \tokens -> case tokens of
       (Token Duration dd:
        Token RegexMatch (GroupMatch (match:_)):
        _) -> case Text.toLower match of
-        "ago" -> tt $ durationAgo dd
+        "ago"      -> tt $ durationAgo dd
+        "previous" -> tt $ durationAgo dd
+        "before"   -> tt $ durationAgo dd
         _     -> tt $ inDuration dd
       _ -> Nothing
   }

--- a/Duckling/Time/Types.hs
+++ b/Duckling/Time/Types.hs
@@ -111,7 +111,7 @@ instance Resolve TimeData where
       ahead:nextAhead:_
         | notImmediate && isJust (timeIntersect ahead refTime) -> Just nextAhead
       ahead:_ -> Just ahead
-    values <- Just . take 3 $ if List.null future then past else future
+    values <- Just . take 3 $ if List.null past then future else past
     Just $ case direction of
       Nothing -> (TimeValue (timeValue tzSeries value)
         (map (timeValue tzSeries) values) holiday, latent)

--- a/Duckling/TimeGrain/EN/Rules.hs
+++ b/Duckling/TimeGrain/EN/Rules.hs
@@ -26,7 +26,7 @@ grains = [ ("second (grain) ", "sec(ond)?s?",      TG.Second)
          , ("day (grain)"    , "days?",            TG.Day)
          , ("week (grain)"   , "weeks?",           TG.Week)
          , ("month (grain)"  , "months?",          TG.Month)
-         , ("quarter (grain)", "(quarter|qtr)s?",  TG.Quarter)
+         , ("quarter (grain)", "(financial )?(quarter|qtr)s?",  TG.Quarter)
          , ("year (grain)"   , "y(ea)?rs?",        TG.Year)
          ]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-![Duckling Logo](https://github.com/facebook/duckling/raw/master/logo.png)
+# Fork information
 
-# Duckling [![Build Status](https://travis-ci.org/facebook/duckling.svg?branch=master)](https://travis-ci.org/facebook/duckling)
+This fork was created from commit **8d681f7** on Facebook's master branch (Dec 2019). The newest tagged version before this commit was v0.1.6.1 (Jun 2018).
+
+Tags on Clinc's fork follow [Semantic Versioning](https://semver.org/), starting from 0.2.0:
+
+The first tagged version is:
+c0.2.0 (**c** = Clinc Version)
+
+# Duckling 
 Duckling is a Haskell library that parses text into structured data.
 
 ```


### PR DESCRIPTION
Could this pull request please be merged into our Duckling repo?

After merging, a new release needs to be manually created with the version name 'c0.2.0'. The change-log is as follows:

---
Modified Duckling's English-language date parsing:

* Return past dates by default instead of future dates (e.g. May 9 -> May 9 of 2019/2018/2017, not May 9 of 2020/2021/2022)
* Can use **financial quarter** instead of just quarter (e.g. third financial quarter of 2019)
* Can use between/and, e.g. between 5 and 9 May of 2019, between May 5 and 9
* Added previous/before/later, e.g. 1 week later
* Added "present" (present = today)