### PR TITLE
feat: ordinal weekday recurrence

### DIFF
--- a/Duckling/Recurrence/EN/Corpus.hs
+++ b/Duckling/Recurrence/EN/Corpus.hs
@@ -56,15 +56,18 @@ examples :: ToJSON a => (Context -> a) -> [Text] -> [Example]
 examples f = examplesCustom (check f)
 
 recurrence :: Int -> Int -> Grain -> Context -> RecurrenceValue 
-recurrence v t g ctx = RecurrenceValue{TRecurrence.rValue = v, TRecurrence.rTimes = t, TRecurrence.rGrain = g, TRecurrence.rAnchor = Nothing}
+recurrence v t g ctx = RecurrenceValue{TRecurrence.rValue = v, TRecurrence.rTimes = t, TRecurrence.rGrain = g, TRecurrence.rAnchor = Nothing, TRecurrence.rInnerGrain = Nothing, TRecurrence.rInnerDay = Nothing, TRecurrence.rInnerInstance = Nothing}
 
 anchoredRecurrence :: Int -> Int -> Grain -> Datetime -> Grain -> Context -> RecurrenceValue 
-anchoredRecurrence v t g dt dtg ctx = RecurrenceValue{TRecurrence.rValue = v, TRecurrence.rTimes = t, TRecurrence.rGrain = g, TRecurrence.rAnchor = a}
+anchoredRecurrence v t g dt dtg ctx = RecurrenceValue{TRecurrence.rValue = v, TRecurrence.rTimes = t, TRecurrence.rGrain = g, TRecurrence.rAnchor = a, TRecurrence.rInnerGrain = Nothing, TRecurrence.rInnerDay = Nothing, TRecurrence.rInnerInstance = Nothing}
   where
     a = Just $ datetime dt dtg ctx
 
+instancedRecurrence :: Maybe Int -> Maybe Int -> Grain -> Maybe Grain -> Context -> RecurrenceValue 
+instancedRecurrence n d g ig ctx = RecurrenceValue{TRecurrence.rValue = 1, TRecurrence.rTimes = 1, TRecurrence.rGrain = g, TRecurrence.rAnchor = Nothing, TRecurrence.rInnerGrain = ig, TRecurrence.rInnerDay = d, TRecurrence.rInnerInstance = n}
+
 anchoredRecurrenceHoliday :: Int -> Int -> Grain -> Datetime -> Grain -> Text -> Context -> RecurrenceValue 
-anchoredRecurrenceHoliday v t g dt dtg h ctx = RecurrenceValue{TRecurrence.rValue = v, TRecurrence.rTimes = t, TRecurrence.rGrain = g, TRecurrence.rAnchor = a}
+anchoredRecurrenceHoliday v t g dt dtg h ctx = RecurrenceValue{TRecurrence.rValue = v, TRecurrence.rTimes = t, TRecurrence.rGrain = g, TRecurrence.rAnchor = a, TRecurrence.rInnerGrain = Nothing, TRecurrence.rInnerDay = Nothing, TRecurrence.rInnerInstance = Nothing}
   where
     a = Just $ datetimeHoliday dt dtg h ctx
 
@@ -173,5 +176,51 @@ allExamples = concat
     , "per 2 quarters"
     , "biquarterly"
     , "every two quarters"
+    ]
+  , examples (instancedRecurrence (Just 3) (Just 6) Month (Just Week))
+    [ "3rd saturday of every month"
+    , "third saturday each month"
+    , "3rd saturday each month"
+    ]
+  , examples (instancedRecurrence (Just 1) (Just 7) Year (Just Week))
+    [ "1st sunday of each year"
+    , "first sunday every year"
+    , "1st sunday per year"
+    ]
+  , examples (instancedRecurrence (Just 2) (Just 1) Month (Just Week))
+    [ "second monday of every month"
+    , "2nd monday each month"
+    ]
+  , examples (instancedRecurrence (Just 3) Nothing Year (Just Week))
+    [ "third week of every year"
+    , "3rd week each year"
+    ]
+  , examples (instancedRecurrence (Just 5) Nothing Year (Just Month))
+    [ "fifth month each year"
+    , "5th month per year"
+    ]
+  , examples (instancedRecurrence Nothing (Just 15) Month (Just Month))
+    [ "15th of every month"
+    ]
+  , examples (instancedRecurrence (Just 15) Nothing Month (Just Day))
+    [ "15th day of every month"
+    ]
+  , examples (instancedRecurrence (Just (- 1)) Nothing Month (Just Day))
+    [ "last day of every month"
+    ]
+  , examples (instancedRecurrence (Just (- 1)) (Just 5) Month (Just Week))
+    [ "last friday of every month"
+    ]
+  , examples (instancedRecurrence Nothing (Just 7) Week (Just Week))
+    [ "7th of every week"
+    ]
+  , examples (instancedRecurrence Nothing (Just 31) Month (Just Month))
+    [ "31st of every month"
+    ]
+  , examples (instancedRecurrence (Just 12) Nothing Year (Just Month))
+    [ "12th month of every year"
+    ]
+  , examples (instancedRecurrence Nothing (Just 31) Year (Just Month))
+    [ "31st of every year"
     ]
   ]

--- a/Duckling/Recurrence/Helpers.hs
+++ b/Duckling/Recurrence/Helpers.hs
@@ -16,6 +16,8 @@ module Duckling.Recurrence.Helpers
   , recurrentDimension
   , isBasicRecurrence
   , mkComposite
+  , dowRecurrence
+  , instancedRecurrence
   , tr
   ) where
 
@@ -58,13 +60,19 @@ tr :: RecurrenceData -> Maybe Token
 tr = Just . Token Recurrence
 
 recurrence :: TG.Grain -> Int -> RecurrenceData
-recurrence g v = RecurrenceData {TRecurrence.grain = g, TRecurrence.value = v, TRecurrence.anchor = Nothing, TRecurrence.times = 1, TRecurrence.composite = False}
+recurrence g v = RecurrenceData {TRecurrence.grain = g, TRecurrence.value = v, TRecurrence.anchor = Nothing, TRecurrence.times = 1, TRecurrence.composite = False, TRecurrence.innerGrain = Nothing, TRecurrence.innerDay = Nothing,TRecurrence.innerInstance = Nothing}
 
 timedRecurrence :: TG.Grain -> Int -> Int -> RecurrenceData
-timedRecurrence g v t = RecurrenceData {TRecurrence.grain = g, TRecurrence.value = v, TRecurrence.anchor = Nothing, TRecurrence.times = t, TRecurrence.composite = False}
+timedRecurrence g v t = RecurrenceData {TRecurrence.grain = g, TRecurrence.value = v, TRecurrence.anchor = Nothing, TRecurrence.times = t, TRecurrence.composite = False, TRecurrence.innerGrain = Nothing, TRecurrence.innerDay = Nothing,TRecurrence.innerInstance = Nothing}
 
 anchoredRecurrence :: TG.Grain -> Int -> TimeData -> RecurrenceData
-anchoredRecurrence g v a = RecurrenceData {TRecurrence.grain = g, TRecurrence.value = v, TRecurrence.anchor = Just a, TRecurrence.times = 1, TRecurrence.composite = False}
+anchoredRecurrence g v a = RecurrenceData {TRecurrence.grain = g, TRecurrence.value = v, TRecurrence.anchor = Just a, TRecurrence.times = 1, TRecurrence.composite = False, TRecurrence.innerGrain = Nothing, TRecurrence.innerDay = Nothing, TRecurrence.innerInstance = Nothing}
 
 mkComposite :: RecurrenceData -> Int -> RecurrenceData
-mkComposite RecurrenceData { TRecurrence.grain = g, TRecurrence.value = v, TRecurrence.anchor = a, TRecurrence.times = t } t' = RecurrenceData {TRecurrence.grain = g, TRecurrence.value = v, TRecurrence.anchor = a, TRecurrence.times = t * t', TRecurrence.composite = True}
+mkComposite RecurrenceData { TRecurrence.grain = g, TRecurrence.value = v, TRecurrence.anchor = a, TRecurrence.times = t, TRecurrence.innerGrain = w, TRecurrence.innerInstance = wn} t' = RecurrenceData {TRecurrence.grain = g, TRecurrence.value = v, TRecurrence.anchor = a, TRecurrence.times = t * t', TRecurrence.composite = True, TRecurrence.innerGrain = w, TRecurrence.innerDay = Nothing, TRecurrence.innerInstance = wn}
+
+dowRecurrence :: Int -> TimeData -> TG.Grain -> TG.Grain -> RecurrenceData
+dowRecurrence wn wd g ig = RecurrenceData {TRecurrence.grain = g, TRecurrence.value = 1, TRecurrence.anchor = Just wd, TRecurrence.times = 1, TRecurrence.composite = False, TRecurrence.innerGrain = Just ig, TRecurrence.innerDay = Nothing, TRecurrence.innerInstance = Just wn}
+
+instancedRecurrence :: Maybe Int -> Maybe Int -> TG.Grain -> TG.Grain -> RecurrenceData
+instancedRecurrence it is g ig = RecurrenceData {TRecurrence.grain = g, TRecurrence.value = 1, TRecurrence.anchor = Nothing, TRecurrence.times = 1, TRecurrence.composite = False, TRecurrence.innerGrain = Just ig, TRecurrence.innerDay = is, TRecurrence.innerInstance = it}

--- a/Duckling/Recurrence/Types.hs
+++ b/Duckling/Recurrence/Types.hs
@@ -19,6 +19,7 @@ import Data.Aeson (object, KeyValue((.=)), ToJSON(toJSON))
 import Data.Hashable (Hashable(hashWithSalt))
 import Data.Text (Text)
 import qualified Data.Time as Time
+import qualified Data.Time.Calendar.WeekDate as Time
 import Data.Tuple.Extra (both)
 import GHC.Generics (Generic)
 import TextShow (showt)
@@ -26,85 +27,125 @@ import Data.Maybe (fromJust)
 
 import Duckling.Resolve (Resolve(..))
 import Duckling.TimeGrain.Types (Grain(..), inSeconds)
-import Duckling.Time.Types (TimeData(..), TimeValue(..), SingleTimeValue(..), InstantValue(..))
+import Duckling.Time.Types (TimeData(..), TimeValue(..), SingleTimeValue(..), InstantValue(..), start)
 import qualified Duckling.TimeGrain.Types as TG
 import Control.Monad (join)
 
 data RecurrenceData = RecurrenceData
-  { value     :: Int
-  , times     :: Int
-  , grain     :: Grain
-  , anchor    :: Maybe TimeData
-  , composite :: Bool
+  { value      :: Int
+  , times      :: Int
+  , grain      :: Grain
+  , anchor     :: Maybe TimeData
+  , composite  :: Bool
+  , innerGrain :: Maybe Grain
+  , innerDay   :: Maybe Int
+  , innerInstance  :: Maybe Int
   }
   deriving (Eq, Generic, Ord, Show, NFData)
 
 instance Hashable RecurrenceData where
-  hashWithSalt s (RecurrenceData value times grain _ _) = hashWithSalt s
+  hashWithSalt s (RecurrenceData value times grain _ _ _ _ _) = hashWithSalt s
     (0::Int, (value, times, grain))
 
 data RecurrenceValue = RecurrenceValue
-  { rValue  :: Int
-  , rTimes  :: Int
-  , rGrain  :: Grain
-  , rAnchor :: Maybe TimeValue
+  { rValue      :: Int
+  , rTimes      :: Int
+  , rGrain      :: Grain
+  , rAnchor     :: Maybe TimeValue
+  , rInnerGrain :: Maybe Grain
+  , rInnerDay   :: Maybe Int
+  , rInnerInstance   :: Maybe Int
   }
   deriving (Eq, Show)
 
 instance Resolve RecurrenceData where
   type ResolvedValue RecurrenceData = RecurrenceValue
-  resolve context options RecurrenceData {value, times, grain, anchor} = do
-    Just $ case anchor of
-      Nothing -> (RecurrenceValue value times grain Nothing, False)
-      Just d -> do
-        (RecurrenceValue value times g a, False)
+  resolve context options RecurrenceData {value, times, grain, anchor, innerGrain, innerDay, innerInstance} = do
+    Just $ case (anchor, innerGrain) of
+      (Nothing, Nothing) -> (RecurrenceValue value times grain Nothing Nothing Nothing Nothing, False)
+      (Nothing, Just ig) -> (RecurrenceValue value times grain Nothing innerGrain innerDay innerInstance, False)
+      (Just d, Nothing) -> do
+        (RecurrenceValue value times g a Nothing Nothing Nothing, False)
         where
           a = unwrapValue $ resolve context options d
+
+          -- grain calculation
           g = case a of
             Just tv -> g
               where
-                -- determine grain from distance between values
                 (v, vals) = getVals tv
                 g = case vals of
-                  (alt:_) -> g
-                    where
-                      g = case (getUTC v, getUTC alt) of
-                        (Just t1, Just t2) -> do
-                          let (d, _) = properFraction $ Time.diffUTCTime t1 t2
-                          let delta = abs d
-                          if      delta <= 10000 then
-                            TG.Year
-                          else if delta <= 100000 then
-                            TG.Day
-                          else if delta <= 1000000 then
-                            TG.Week
-                          else if delta <= 10000000 then
-                            TG.Month
-                          else
-                            TG.Year
-                        _  -> grain
-                      getUTC :: SingleTimeValue -> Maybe Time.UTCTime 
-                      getUTC (SimpleValue (InstantValue v g)) = Just $ Time.zonedTimeToUTC v
-                      getUTC _ = Nothing
-                  [] -> grain
-                getVals :: TimeValue -> (SingleTimeValue, [SingleTimeValue])
-                getVals (TimeValue val vals text) = (val, vals)
-            Nothing -> grain
-          unwrapValue :: Maybe (TimeValue, Bool) -> Maybe TimeValue
-          unwrapValue tup = case tup of
-            Just (val, _) -> Just val
-            Nothing       -> Nothing
+                  (alt1:alt2:_) -> case (getUTC v, getUTC alt1, getUTC alt2) of
+                    (Just t1, Just t2, Just t3) -> do
+                      let (d1, _) = properFraction $ Time.diffUTCTime t1 t2
+                      let (d2, _) = properFraction $ Time.diffUTCTime t1 t3
+                      calcGrain $ max (abs d1) (abs d2)
+                    _  -> grain
+                  (alt:_) -> case (getUTC v, getUTC alt) of
+                    (Just t1, Just t2) -> do
+                      let (d1, _) = properFraction $ Time.diffUTCTime t1 t2
+                      calcGrain d1
+                    _  -> grain
+                  _ -> grain
+            _ -> grain
+      (Just d, Just ig) -> do
+        (RecurrenceValue value times grain Nothing innerGrain innerDay innerInstance, False)
+        where
+          a = unwrapValue $ resolve context options d
+
+          -- weekday calculation
+          innerDay = case (a, innerGrain) of
+            (Just tv, Just TG.Week) -> wd
+              where
+                -- get day of week from date
+                (v, _) = getVals tv
+                utc = getUTC v
+                wd = case utc of
+                  Just t -> do
+                    let Time.UTCTime day _ = t
+                    let (_, _, dow) = Time.toWeekDate day
+                    Just dow
+            _ -> Nothing
 
 instance ToJSON RecurrenceValue where
-  toJSON RecurrenceValue {rValue, rTimes, rGrain, rAnchor} = object
+  toJSON RecurrenceValue {rValue, rTimes, rGrain, rAnchor, rInnerGrain, rInnerDay, rInnerInstance} = object
     [ "type"       .= ("value" :: Text)
     , "value"      .= rValue
     , "times"      .= rTimes
     , "unit"       .= rGrain
     , "anchor"     .= rAnchor
-    , showt rGrain  .= rValue
+    , showt rGrain .= rValue
+    , "inner"      .= object
+      [ "grain"    .= rInnerGrain
+      , "day"      .= rInnerDay
+      , "instance" .= rInnerInstance
+      ]
     , "normalized" .= object
       [ "unit"  .= ("second" :: Text)
       , "value" .= inSeconds rGrain rValue
       ]
     ]
+
+-- extracts a resolved TimeValue
+unwrapValue :: Maybe (TimeValue, Bool) -> Maybe TimeValue
+unwrapValue tup = case tup of
+  Just (val, _) -> Just val
+  _             -> Nothing
+
+-- converts a TimeValue to UTC
+getUTC :: SingleTimeValue -> Maybe Time.UTCTime 
+getUTC (SimpleValue (InstantValue v g)) = Just $ Time.zonedTimeToUTC v
+getUTC _ = Nothing
+
+-- extracts base and alternative TimeValues from a TimeValue
+getVals :: TimeValue -> (SingleTimeValue, [SingleTimeValue])
+getVals (TimeValue val vals text) = (val, vals)
+
+-- calculates grain from delta between time values
+calcGrain :: Int -> TG.Grain
+calcGrain delta
+  | delta <= 10000 = TG.Year
+  | delta <= 100000 = TG.Day
+  | delta <= 2000000 = TG.Week
+  | delta <= 10000000 = TG.Month
+  | otherwise = TG.Year


### PR DESCRIPTION
Adds recurrence support for the following examples:
- first monday of every month
- second tuesday each month
- fifth friday of every year
- third week of every year
- 5th month per year
- 15th of every month
- 15th day of every month
- last day of every month
- last friday of every month

Exposes `inner` as a new object on a recurrence response with the following structure (e.g. "third monday of every month"):
```json
{
    "inner": {
        "grain": "week",
        "day": 1,
        "instance": 3
    }
}
```
- grain: inner grain of the recurrence
- day: day within the grain that is repeated. With `inner.grain=week`, this is 1-7 for Monday-Sunday. Otherwise, this corresponds to 1-31 for days in a given month.
- instance: how many of `inner.grain` to skip within the outer grain (`unit`). For the example above, we skip to the 3rd week since `instance=3`. This value can be 1-n referring to the instance of `inner.grain` within `unit` and additionally can be -1 which refers to the last instance of `inner.grain` within `unit`.

This is particularly helpful for things like recurring transfers which happen on a specific day each month.